### PR TITLE
Add "bacon" command and refine "mcstatus" command

### DIFF
--- a/src/Shotbow/ChatBot/Bot.php
+++ b/src/Shotbow/ChatBot/Bot.php
@@ -535,7 +535,39 @@ MySQL;
 
     protected function command_mcstatus(Shotbow_ChatBot_User $sender, $arguments)
     {
-        $message = "Sometimes it's Mojang.  [url=http://xpaw.ru/mcstatus/]Have you checked?[/url]";
+        $scan = json_decode(file_get_contents("https://status.mojang.com/check"), true);
+
+        $errors = array();
+
+        if ($scan[0]["minecraft.net"] !== "green") {
+            $errors[] = "Minecraft is down: ";
+        }
+
+        if ($scan[1]["session.minecraft.net"] !== "green" || $scan[6]["sessionserver.mojang.com"] !== "green") {
+            $errors[] = "All server sessions are down. ";
+        }
+
+        if ($scan[2]["account.mojang.com"] !== "green") {
+            $errors[] = "Account services are down. ";
+        }
+
+        if ($scan[3]["auth.mojang.com"] !== "green" || $scan[5]["authserver.mojang.com"] !== "green") {
+            $errors[] = "Authentication servers are down. ";
+        }
+
+        if ($scan[4]["skins.minecraft.net"] !== "green") {
+            $errors[] = "Skin servers are down. ";
+        }
+
+        $message = "Sometimes it's Mojang... ";
+        
+        if (count($errors) !== 0) {
+            foreach ($errors as $i) {
+                $message .= $i;
+            }
+        } else {
+            $message .= "but today, it seems like all of Mojang's servers are working fine!";
+        }
         $this->postMessage($message);
     }
 

--- a/src/Shotbow/ChatBot/Bot.php
+++ b/src/Shotbow/ChatBot/Bot.php
@@ -236,6 +236,7 @@ MySQL;
                 'contact'  => [$this, 'command_contact'],
                 'why'      => [$this, 'command_why'],
                 'math'     => [$this, 'command_math'],
+                'bacon'     => [$this, 'command_bacon'],
             ];
         }
 
@@ -535,7 +536,7 @@ MySQL;
 
     protected function command_mcstatus(Shotbow_ChatBot_User $sender, $arguments)
     {
-        //TODO: "Better logic" - Navarr 2k16
+        // TODO "Better logic" - Navarr 2k16
         $scan = json_decode(file_get_contents("https://status.mojang.com/check"), true);
 
         $errors = array();
@@ -561,7 +562,7 @@ MySQL;
         }
 
         $message = "Sometimes it's Mojang... ";
-        
+
         if (count($errors) !== 0) {
             foreach ($errors as $i) {
                 $message .= $i;
@@ -647,6 +648,14 @@ MySQL;
             } catch (Exception $e) {
                 $this->postMessage('I\'m sorry, but I don\'t recognize that as a mathematical expression.  Feel free to try another.');
             }
+        }
+    }
+
+    protected function command_bacon(Shotbow_ChatBot_User $sender, $arguments)
+    {
+        if (in_array($sender->getId(), [319, 1330069, 262846])
+          $action = "Shoves [url=https://i.imgur.com/F0Lon2j.jpg]bacon[/url] down ".$sender."'s throat.'";
+          $this->postAction($action);
         }
     }
 }

--- a/src/Shotbow/ChatBot/Bot.php
+++ b/src/Shotbow/ChatBot/Bot.php
@@ -653,8 +653,8 @@ MySQL;
 
     protected function command_bacon(Shotbow_ChatBot_User $sender, $arguments)
     {
-        if (in_array($sender->getId(), [319, 1330069, 262846]) {
-          $action = "Shoves [url=https://i.imgur.com/F0Lon2j.jpg]bacon[/url] down ".$sender."'s throat.'";
+        if (in_array($sender->getId(), [319, 1330069, 262846])) {
+          $action = "Shoves [url=https://i.imgur.com/F0Lon2j.jpg]bacon[/url] down ".$sender."'s throat.";
           $this->postAction($action);
         }
     }

--- a/src/Shotbow/ChatBot/Bot.php
+++ b/src/Shotbow/ChatBot/Bot.php
@@ -535,6 +535,7 @@ MySQL;
 
     protected function command_mcstatus(Shotbow_ChatBot_User $sender, $arguments)
     {
+        //TODO: "Better logic" - Navarr 2k16
         $scan = json_decode(file_get_contents("https://status.mojang.com/check"), true);
 
         $errors = array();

--- a/src/Shotbow/ChatBot/Bot.php
+++ b/src/Shotbow/ChatBot/Bot.php
@@ -653,7 +653,7 @@ MySQL;
 
     protected function command_bacon(Shotbow_ChatBot_User $sender, $arguments)
     {
-        if (in_array($sender->getId(), [319, 1330069, 262846])
+        if (in_array($sender->getId(), [319, 1330069, 262846]) {
           $action = "Shoves [url=https://i.imgur.com/F0Lon2j.jpg]bacon[/url] down ".$sender."'s throat.'";
           $this->postAction($action);
         }


### PR DESCRIPTION
The "mcstatus" hasn't changed since my last PR. 

The "bacon" command was requested by JumJumJR around two years ago and has had tons of vouches, [if you want to check it out](https://shotbow.net/forum/threads/petition-to-add-a-bacon-command-to-chatbot.153022/#post-1147048). The bacon command can only be used by Navarr, JumJumJR, and myself (at the moment, but we can change that easily).

(sorry for this -- it's V3 -- StyleCI picked up a dumb syntax error)
